### PR TITLE
Require execjs in Ngannotate::Processor

### DIFF
--- a/lib/ngannotate/processor.rb
+++ b/lib/ngannotate/processor.rb
@@ -1,3 +1,4 @@
+require 'execjs'
 require 'sprockets/processor'
 
 module Ngannotate

--- a/ngannotate-rails.gemspec
+++ b/ngannotate-rails.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 3.1"
+  spec.add_runtime_dependency "execjs"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
I was running into "undefined Ngannotate::Processor::ExecJS" when running with NG_FORCE=true because none of the other typical sprockets processors that require execjs were being required beforehand.
