### PR TITLE
Update readme to update ES version and add coffeescript for ngInject

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ gem 'mini_racer', '~> 0.1.4'
 gem 'sprockets-babel', git: 'https://github.com/kikonen/sprockets-babel.git', tag: '0.0.6.2'
 ```
 
-#### ES& support
+#### ES2015+/coffeescript support
 
-If using ES6, it's recommended to use explicit "ngInject;" for classes.
+If using ES2015+ or coffeescript, it's recommended to use explicit "ngInject;" for classes.
 
 test_controller.es6
 ```javascript


### PR DESCRIPTION
Javascript versioning has changed to using the full year so ES6 should be referred to as ES2015 and the ngInject is also required for coffeescript so that's worth mentioning in the readme.